### PR TITLE
Adiciona câmera

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ fn main() -> GameResult {
     let window_setup = WindowSetup::default().title(GAME_NAME).vsync(false);
 
     let window_mode = WindowMode::default()
-        //.dimensions(1280.0, 720.0)
         //.fullscreen_type(FullscreenType::Desktop)
         .dimensions(854.0, 480.0)
         .resizable(false);

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -5,6 +5,14 @@ use ggez::GameResult;
 use glam::*;
 
 /// Represents data related to camera.
+/// 
+/// Remember that this is not a component. Each screen should have
+/// its camera instantiated, and it should be updated according to
+/// whatever objects it follows.
+/// 
+/// The camera is to be mostly understood as this element which
+/// recalculates elements' position for rendering, and is not an
+/// actual object to be contained on the scene.
 #[derive(Debug, PartialEq)]
 pub struct Camera {
     pub position: Position,
@@ -12,9 +20,29 @@ pub struct Camera {
     center: Vec2,
 }
 
+
+/// Describes the vertical behaviour of the camera.
+/// 
+/// This behaviour mostly relates to how the Player is behaving
+/// on scene.
 pub enum CameraVerticalBehaviour {
+    /// When the player is on the ground, follow it so that
+    /// the camera is always centered on the Y axis. The camera
+    /// lags behind slowly, but finds the player at a pace of 6
+    /// pixels per frame at most.
     CenterYSlow,
+    /// When the player is on the ground, follow it so that
+    /// the camera is always centered on the Y axis. The camera
+    /// lags behind slowly, but finds the player at a pace of 16
+    /// pixels per frame at most.
     CenterYFast,
+    /// Default behaviour, and also the behaviour whenever the
+    /// player is in the air. The camera respects the boundaries
+    /// that were set, so that the player lags behind on Y axis.
+    /// If it goes beyond the minimum or maximum Y boundaries, the
+    /// camera finds the player at a pace of 16 pixels per frame
+    /// at most, so that the player is contained inside the
+    /// boundaries again.
     RespectBounds,
 }
 
@@ -24,6 +52,7 @@ fn get_screen_center(context: &Context) -> Vec2 {
 }
 
 impl Camera {
+    /// Create a new camera object with its default boundaries.
     pub fn new(context: &Context) -> Self {
         Self {
             position: Position::default(),
@@ -32,6 +61,10 @@ impl Camera {
         }
     }
 
+    /// Transform a vertex so that it is contained on screen.GameResult
+    /// 
+    /// This function should be used to recalculate the position of
+    /// any elements being drawn on screen.
     pub fn transform(&self, vertex: Vec2) -> Vec2 {
         (vertex.clone() - self.position.0) + self.center
     }
@@ -46,6 +79,9 @@ impl Camera {
         )
     }
 
+    /// Update camera position according to its behaviour, specially
+    /// if the camera is supposed to follow any object on screen, whose
+    /// position may be optionally passed as well.
     pub fn update(
         &mut self,
         followed: Option<&Position>,
@@ -102,6 +138,8 @@ impl Camera {
         Ok(())
     }
 
+    /// Draw a debug indicator on the center of screen so that one can
+    /// debug the behaviour of camera.
     pub fn debug_draw(&self, context: &mut Context) -> GameResult {
         let camera_mesh = MeshBuilder::new()
             .rectangle(DrawMode::stroke(1.0), self.border, Color::WHITE)?

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -12,6 +12,12 @@ pub struct Camera {
     center: Vec2,
 }
 
+pub enum CameraVerticalBehaviour {
+    CenterYSlow,
+    CenterYFast,
+    RespectBounds,
+}
+
 fn get_screen_center(context: &Context) -> Vec2 {
     let rect = graphics::screen_coordinates(context);
     glam::vec2(rect.w / 2.0, rect.h / 2.0)
@@ -19,7 +25,7 @@ fn get_screen_center(context: &Context) -> Vec2 {
 
 impl Camera {
     pub fn new(context: &Context) -> Self {
-         Self {
+        Self {
             position: Position::default(),
             border: Rect::new(-16.0, -32.0, 16.0, 64.0),
             center: get_screen_center(context),
@@ -30,11 +36,69 @@ impl Camera {
         (vertex.clone() - self.position.0) + self.center
     }
 
-    pub fn update(&mut self, followed: Option<&Position>) -> GameResult {
-        // TODO!
-        if let Some(followpos) = followed {
-            self.position.0 = followpos.0;
+    fn boundaries(&self) -> (f32, f32, f32, f32) {
+        let pos = self.position.0;
+        (
+            pos.x + self.border.x,                 // Left
+            pos.x + self.border.x + self.border.w, // Right
+            pos.y + self.border.y,                 // Top
+            pos.y + self.border.y + self.border.h, // Bottom
+        )
+    }
+
+    pub fn update(
+        &mut self,
+        followed: Option<&Position>,
+        vbehaviour: CameraVerticalBehaviour,
+    ) -> GameResult {
+        if let Some(followed_pos) = followed {
+            let (left, right, top, bottom) = self.boundaries();
+            let target = followed_pos.0;
+
+            // Horizontal borders
+            self.position.0.x += if target.x < left {
+                -(left - target.x).min(16.0)
+            } else if target.x > right {
+                (target.x - right).min(16.0)
+            } else {
+                0.0
+            };
+
+            // Vertical borders
+            self.position.0.y += match vbehaviour {
+                CameraVerticalBehaviour::CenterYSlow => {
+                    if target.y < self.position.0.y {
+                        -(self.position.0.y - target.y).min(6.0)
+                    } else if target.y > self.position.0.y {
+                        (target.y - self.position.0.y).min(6.0)
+                    } else {
+                        0.0
+                    }
+                },
+                CameraVerticalBehaviour::CenterYFast => {
+                    if target.y < self.position.0.y {
+                        -(self.position.0.y - target.y).min(16.0)
+                    } else if target.y > self.position.0.y {
+                        (target.y - self.position.0.y).min(16.0)
+                    } else {
+                        0.0
+                    }
+                },
+                CameraVerticalBehaviour::RespectBounds => {
+                    if target.y < top {
+                        -(top - target.y).min(16.0)
+                    } else if target.y > bottom {
+                        (target.y - bottom).min(16.0)
+                    } else {
+                        0.0
+                    }
+                },
+            };
         }
+
+        // Prevent going beyond minimum position
+        self.position.0 = self.position.0.max(self.center);
+
         Ok(())
     }
 

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -54,7 +54,7 @@ pub enum CameraVerticalBehaviour {
 }
 
 /// Describes the displacement behaviour of the camera.
-/// 
+///
 /// The displacement behaviour changes the camera center so that
 /// the camera slowly pans towards some direction. This is
 /// particularly useful to make the character look up or down,
@@ -69,6 +69,10 @@ pub enum CameraDisplacementBehaviour {
     /// Slowly moves down the camera until it reaches
     /// 88 pixels down.
     LookDown,
+    /// Slowly moves the camera until it reaches 64 pixels left.
+    ExtendLeft,
+    /// Slowly moves the camera until it reaches 64 pixels right.
+    ExtendRight,
 }
 
 fn get_screen_center(context: &Context) -> Vec2 {
@@ -157,24 +161,35 @@ impl Camera {
             };
         }
 
-        // Apply displacement behaviour
-        match self.displacement_behaviour {
-            CameraDisplacementBehaviour::None => {
-                self.displacement.y = if self.displacement.y > 0.0 {
+        // Apply X axis displacement behaviour
+        self.displacement.x = match self.displacement_behaviour {
+            CameraDisplacementBehaviour::ExtendRight => (self.displacement.x + 2.0).min(64.0),
+            CameraDisplacementBehaviour::ExtendLeft => (self.displacement.x - 2.0).max(-64.0),
+            _ => {
+                if self.displacement.x > 0.0 {
+                    (self.displacement.x - 2.0).max(0.0)
+                } else if self.displacement.x < 0.0 {
+                    (self.displacement.x + 2.0).min(0.0)
+                } else {
+                    0.0
+                }
+            }
+        };
+
+        // Apply Y axis displacement behaviour
+        self.displacement.y = match self.displacement_behaviour {
+            CameraDisplacementBehaviour::LookDown => (self.displacement.y + 2.0).min(88.0),
+            CameraDisplacementBehaviour::LookUp => (self.displacement.y - 2.0).max(-104.0),
+            _ => {
+                if self.displacement.y > 0.0 {
                     (self.displacement.y - 2.0).max(0.0)
                 } else if self.displacement.y < 0.0 {
                     (self.displacement.y + 2.0).min(0.0)
                 } else {
                     0.0
-                };
+                }
             }
-            CameraDisplacementBehaviour::LookDown => {
-                self.displacement.y = (self.displacement.y + 2.0).min(88.0)
-            }
-            CameraDisplacementBehaviour::LookUp => {
-                self.displacement.y = (self.displacement.y - 2.0).max(-104.0)
-            }
-        }
+        };
 
         // Define position considering displacement. Also prevent
         // going beyond minimum position

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -99,7 +99,7 @@ impl Camera {
     /// This function should be used to recalculate the position of
     /// any elements being drawn on screen.
     pub fn transform(&self, vertex: Vec2) -> Vec2 {
-        (vertex.clone() - self.position.0) + self.center
+        (vertex - self.position.0) + self.center
     }
 
     fn boundaries(&self) -> (f32, f32, f32, f32) {

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -5,26 +5,33 @@ use ggez::GameResult;
 use glam::*;
 
 /// Represents data related to camera.
-/// 
+///
 /// Remember that this is not a component. Each screen should have
 /// its camera instantiated, and it should be updated according to
 /// whatever objects it follows.
-/// 
+///
 /// The camera is to be mostly understood as this element which
 /// recalculates elements' position for rendering, and is not an
 /// actual object to be contained on the scene.
 #[derive(Debug, PartialEq)]
 pub struct Camera {
+    /// Final position of the camera.
     pub position: Position,
+    /// Vertical behaviour of the camera boundaries.
+    pub vertical_behaviour: CameraVerticalBehaviour,
+    /// Displacement behaviour of the camera.
+    pub displacement_behaviour: CameraDisplacementBehaviour,
+    raw_position: Vec2,
     border: Rect,
     center: Vec2,
+    displacement: Vec2,
 }
 
-
 /// Describes the vertical behaviour of the camera.
-/// 
+///
 /// This behaviour mostly relates to how the Player is behaving
 /// on scene.
+#[derive(Debug, PartialEq)]
 pub enum CameraVerticalBehaviour {
     /// When the player is on the ground, follow it so that
     /// the camera is always centered on the Y axis. The camera
@@ -46,6 +53,24 @@ pub enum CameraVerticalBehaviour {
     RespectBounds,
 }
 
+/// Describes the displacement behaviour of the camera.
+/// 
+/// The displacement behaviour changes the camera center so that
+/// the camera slowly pans towards some direction. This is
+/// particularly useful to make the character look up or down,
+/// or to have an extended camera while running.
+#[derive(Debug, PartialEq)]
+pub enum CameraDisplacementBehaviour {
+    /// No behaviour; centers the camera if not centralized.
+    None,
+    /// Slowly moves up the camera until it reaches
+    /// 104 pixels up.
+    LookUp,
+    /// Slowly moves down the camera until it reaches
+    /// 88 pixels down.
+    LookDown,
+}
+
 fn get_screen_center(context: &Context) -> Vec2 {
     let rect = graphics::screen_coordinates(context);
     glam::vec2(rect.w / 2.0, rect.h / 2.0)
@@ -56,13 +81,17 @@ impl Camera {
     pub fn new(context: &Context) -> Self {
         Self {
             position: Position::default(),
+            raw_position: Vec2::ZERO,
             border: Rect::new(-16.0, -32.0, 16.0, 64.0),
             center: get_screen_center(context),
+            vertical_behaviour: CameraVerticalBehaviour::RespectBounds,
+            displacement_behaviour: CameraDisplacementBehaviour::None,
+            displacement: Vec2::ZERO,
         }
     }
 
     /// Transform a vertex so that it is contained on screen.GameResult
-    /// 
+    ///
     /// This function should be used to recalculate the position of
     /// any elements being drawn on screen.
     pub fn transform(&self, vertex: Vec2) -> Vec2 {
@@ -70,7 +99,7 @@ impl Camera {
     }
 
     fn boundaries(&self) -> (f32, f32, f32, f32) {
-        let pos = self.position.0;
+        let pos = &self.raw_position;
         (
             pos.x + self.border.x,                 // Left
             pos.x + self.border.x + self.border.w, // Right
@@ -82,17 +111,13 @@ impl Camera {
     /// Update camera position according to its behaviour, specially
     /// if the camera is supposed to follow any object on screen, whose
     /// position may be optionally passed as well.
-    pub fn update(
-        &mut self,
-        followed: Option<&Position>,
-        vbehaviour: CameraVerticalBehaviour,
-    ) -> GameResult {
+    pub fn update(&mut self, followed: Option<&Position>) -> GameResult {
         if let Some(followed_pos) = followed {
             let (left, right, top, bottom) = self.boundaries();
             let target = followed_pos.0;
 
             // Horizontal borders
-            self.position.0.x += if target.x < left {
+            self.raw_position.x += if target.x < left {
                 -(left - target.x).min(16.0)
             } else if target.x > right {
                 (target.x - right).min(16.0)
@@ -101,25 +126,25 @@ impl Camera {
             };
 
             // Vertical borders
-            self.position.0.y += match vbehaviour {
+            self.raw_position.y += match self.vertical_behaviour {
                 CameraVerticalBehaviour::CenterYSlow => {
-                    if target.y < self.position.0.y {
-                        -(self.position.0.y - target.y).min(6.0)
-                    } else if target.y > self.position.0.y {
-                        (target.y - self.position.0.y).min(6.0)
+                    if target.y < self.raw_position.y {
+                        -(self.raw_position.y - target.y).min(6.0)
+                    } else if target.y > self.raw_position.y {
+                        (target.y - self.raw_position.y).min(6.0)
                     } else {
                         0.0
                     }
-                },
+                }
                 CameraVerticalBehaviour::CenterYFast => {
-                    if target.y < self.position.0.y {
-                        -(self.position.0.y - target.y).min(16.0)
-                    } else if target.y > self.position.0.y {
-                        (target.y - self.position.0.y).min(16.0)
+                    if target.y < self.raw_position.y {
+                        -(self.raw_position.y - target.y).min(16.0)
+                    } else if target.y > self.raw_position.y {
+                        (target.y - self.raw_position.y).min(16.0)
                     } else {
                         0.0
                     }
-                },
+                }
                 CameraVerticalBehaviour::RespectBounds => {
                     if target.y < top {
                         -(top - target.y).min(16.0)
@@ -128,12 +153,32 @@ impl Camera {
                     } else {
                         0.0
                     }
-                },
+                }
             };
         }
 
-        // Prevent going beyond minimum position
-        self.position.0 = self.position.0.max(self.center);
+        // Apply displacement behaviour
+        match self.displacement_behaviour {
+            CameraDisplacementBehaviour::None => {
+                self.displacement.y = if self.displacement.y > 0.0 {
+                    (self.displacement.y - 2.0).max(0.0)
+                } else if self.displacement.y < 0.0 {
+                    (self.displacement.y + 2.0).min(0.0)
+                } else {
+                    0.0
+                };
+            }
+            CameraDisplacementBehaviour::LookDown => {
+                self.displacement.y = (self.displacement.y + 2.0).min(88.0)
+            }
+            CameraDisplacementBehaviour::LookUp => {
+                self.displacement.y = (self.displacement.y - 2.0).max(-104.0)
+            }
+        }
+
+        // Define position considering displacement. Also prevent
+        // going beyond minimum position
+        self.position.0 = (self.raw_position + self.displacement).max(self.center);
 
         Ok(())
     }
@@ -155,6 +200,10 @@ impl Camera {
 
         let screen_center = get_screen_center(context);
 
-        graphics::draw(context, &camera_mesh, (screen_center, 0.0, Color::new(1.0, 1.0, 1.0, 0.1)))
+        graphics::draw(
+            context,
+            &camera_mesh,
+            (screen_center, 0.0, Color::new(1.0, 1.0, 1.0, 0.1)),
+        )
     }
 }

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -155,6 +155,6 @@ impl Camera {
 
         let screen_center = get_screen_center(context);
 
-        graphics::draw(context, &camera_mesh, (screen_center, 0.0, Color::WHITE))
+        graphics::draw(context, &camera_mesh, (screen_center, 0.0, Color::new(1.0, 1.0, 1.0, 0.1)))
     }
 }

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -1,0 +1,54 @@
+use super::general::Position;
+use ggez::graphics::{self, Color, DrawMode, MeshBuilder, Rect};
+use ggez::Context;
+use ggez::GameResult;
+use glam::*;
+
+/// Represents data related to camera.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Camera {
+    pub position: Position,
+    border: Rect,
+    minimum: Vec2,
+}
+
+fn get_screen_center(context: &Context) -> Vec2 {
+    let rect = graphics::screen_coordinates(context);
+    glam::vec2(rect.w / 2.0, rect.h / 2.0)
+}
+
+impl Camera {
+    pub fn new(context: &Context) -> Self {
+         Self {
+            position: Position::default(),
+            border: Rect::new(-16.0, -32.0, 16.0, 64.0),
+            minimum: get_screen_center(context),
+        }
+    }
+
+    pub fn update(&mut self, followed: Option<&Position>) -> GameResult {
+        // TODO!
+        if let Some(position) = followed {
+            self.position.0 = position.0;    
+        }
+        Ok(())
+    }
+
+    pub fn debug_draw(&self, context: &mut Context) -> GameResult {
+        let camera_mesh = MeshBuilder::new()
+            .rectangle(DrawMode::stroke(1.0), self.border, Color::WHITE)?
+            .line(
+                &[
+                    glam::vec2(self.border.x, 0.0),
+                    glam::vec2(self.border.x + self.border.w, 0.0),
+                ],
+                1.0,
+                Color::GREEN,
+            )?
+            .build(context)?;
+
+        let screen_center = get_screen_center(context);
+
+        graphics::draw(context, &camera_mesh, (screen_center, 0.0, Color::WHITE))
+    }
+}

--- a/src/objects/camera.rs
+++ b/src/objects/camera.rs
@@ -5,11 +5,11 @@ use ggez::GameResult;
 use glam::*;
 
 /// Represents data related to camera.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Camera {
     pub position: Position,
     border: Rect,
-    minimum: Vec2,
+    center: Vec2,
 }
 
 fn get_screen_center(context: &Context) -> Vec2 {
@@ -22,14 +22,18 @@ impl Camera {
          Self {
             position: Position::default(),
             border: Rect::new(-16.0, -32.0, 16.0, 64.0),
-            minimum: get_screen_center(context),
+            center: get_screen_center(context),
         }
+    }
+
+    pub fn transform(&self, vertex: Vec2) -> Vec2 {
+        (vertex.clone() - self.position.0) + self.center
     }
 
     pub fn update(&mut self, followed: Option<&Position>) -> GameResult {
         // TODO!
-        if let Some(position) = followed {
-            self.position.0 = position.0;    
+        if let Some(followpos) = followed {
+            self.position.0 = followpos.0;
         }
         Ok(())
     }

--- a/src/objects/general.rs
+++ b/src/objects/general.rs
@@ -29,7 +29,7 @@ impl Position {
 
     /// Wrap a vector into a Position struct
     pub fn wrap(pos: Vec2) -> Self {
-        Self(pos.clone())
+        Self(pos)
     }
 }
 

--- a/src/objects/general.rs
+++ b/src/objects/general.rs
@@ -21,6 +21,16 @@ impl Position {
     pub fn new(x: f32, y: f32) -> Self {
         Self(Vec2::new(x, y))
     }
+
+    /// Create position from another
+    pub fn from(pos: &Self) -> Self {
+        Self(Vec2::new(pos.0.x, pos.0.y))
+    }
+
+    /// Wrap a vector into a Position struct
+    pub fn wrap(pos: Vec2) -> Self {
+        Self(pos.clone())
+    }
 }
 
 /// Represents a direction for anything. May be converted to

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -1,3 +1,4 @@
 pub mod animation;
+pub mod camera;
 pub mod general;
 pub mod player;

--- a/src/objects/player/general.rs
+++ b/src/objects/player/general.rs
@@ -32,11 +32,7 @@ impl Player {
             PlayerConstants::default()
         };
 
-        //let state = PlayerState::default();
-        let state = PlayerState {
-            ground: true,
-            ..PlayerState::default()
-        };
+        let state = PlayerState::default();
         let position = Position::new(30.0, 240.0);
         let speed = PlayerSpeed::default();
         let mut animation_data =
@@ -65,8 +61,6 @@ impl Player {
         let mut animator = Animator::default();
         animator.set("idle".to_string(), &animation_data);
 
-        // TODO: Hitboxes?
-
         Ok(world.push((state, constants, position, speed, animation_data, animator)))
     }
 
@@ -75,11 +69,7 @@ impl Player {
         for (state, position, speed) in query.iter_mut(world) {
             *position = Position::new(30.0, 240.0);
             *speed = PlayerSpeed::default();
-            //state = PlayerState::default();
-            *state = PlayerState {
-                ground: true,
-                ..PlayerState::default()
-            };
+            *state = PlayerState::default();
         }
     }
 }

--- a/src/objects/player/physics.rs
+++ b/src/objects/player/physics.rs
@@ -4,7 +4,7 @@ use crate::objects::general::Position;
 use ggez::GameResult;
 use legion::*;
 
-const FAKE_GROUND_Y: f32 = 800.0;
+pub const FAKE_GROUND_Y: f32 = 800.0;
 
 pub fn update(world: &mut World, input: &Input) -> GameResult {
     use crate::input::InputButton;

--- a/src/objects/player/physics.rs
+++ b/src/objects/player/physics.rs
@@ -4,6 +4,8 @@ use crate::objects::general::Position;
 use ggez::GameResult;
 use legion::*;
 
+const FAKE_GROUND_Y: f32 = 800.0;
+
 pub fn update(world: &mut World, input: &Input) -> GameResult {
     use crate::input::InputButton;
     use crate::objects::general::*;
@@ -22,8 +24,8 @@ pub fn update(world: &mut World, input: &Input) -> GameResult {
         );
 
         // Fake ground. Remove later!
-        if !state.ground && (position.0.y >= 240.0) {
-            position.0.y = 240.0;
+        if !state.ground && (position.0.y >= FAKE_GROUND_Y) {
+            position.0.y = FAKE_GROUND_Y;
             speed.angle = 0.0;
             state.set_ground(true, speed, true);
         }

--- a/src/objects/player/sensors.rs
+++ b/src/objects/player/sensors.rs
@@ -14,7 +14,7 @@ pub struct PlayerSensors;
 impl PlayerSensors {
     /// Draws a representation for player sensors. Requires player data
     /// such as its state, position and rotation.
-    pub fn draw(
+    pub fn debug_draw(
         context: &mut Context,
         state: &PlayerState,
         position: &Position,

--- a/src/objects/player/sensors.rs
+++ b/src/objects/player/sensors.rs
@@ -158,7 +158,7 @@ impl PlayerSensors {
             .rectangle(
                 DrawMode::fill(),
                 hitbox_rect,
-                Color::new(1.0, 0.0, 1.0, 0.5),
+                Color::new(1.0, 0.0, 1.0, 0.1),
             )?
             .build(context)?;
 

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -133,6 +133,43 @@ impl LevelScreenSystem {
         Ok(())
     }
 
+    fn draw_debug_text(
+        &self,
+        context: &mut Context,
+        state: &PlayerState,
+        speed: &PlayerSpeed,
+        pos: &Position,
+    ) -> GameResult {
+        use ggez::graphics::{self, Color, PxScale, Text, TextFragment};
+
+        let mut hud_text = format!(
+            "ACTION {:?}\n\
+             POSX   {:>13.6}\n\
+             POSY   {:>13.6}\n\
+             GSP    {:>13.6}\n\
+             XSP    {:>13.6}\n\
+             YSP    {:>13.6}\n\
+             THETA  {:>13.6}",
+            state.action, pos.0.x, pos.0.y, speed.gsp, speed.xsp, speed.ysp, speed.angle,
+        );
+
+        if let Some(camera) = &self.camera {
+            hud_text = format!(
+                "{}\n\
+            CAMX   {:>13.6}\n\
+            CAMY   {:>13.6}",
+                hud_text, camera.position.0.x, camera.position.0.y,
+            );
+        }
+
+        let text = TextFragment::new(hud_text)
+            .color(Color::WHITE)
+            .scale(PxScale::from(12.0));
+        let text = Text::new(text);
+        graphics::queue_text(context, &text, glam::vec2(10.0, 10.0), None);
+        Ok(())
+    }
+
     pub fn draw(&self, context: &mut Context) -> GameResult {
         // Draw test graphics
         self.draw_test_graphics(context)?;
@@ -158,6 +195,7 @@ impl LevelScreenSystem {
                     position.0
                 });
                 PlayerSensors::debug_draw(context, state, &hotspot, speed)?;
+                self.draw_debug_text(context, state, speed, position)?;
             }
 
             if let Some(camera) = &self.camera {

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -103,7 +103,7 @@ impl LevelScreenSystem {
                 } else {
                     position.0
                 });
-                PlayerSensors::draw(context, state, &hotspot, speed)?;
+                PlayerSensors::debug_draw(context, state, &hotspot, speed)?;
             }
 
             if let Some(camera) = &self.camera {

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -90,7 +90,13 @@ impl LevelScreenSystem {
                         _ => CameraDisplacementBehaviour::None,
                     }
                 } else {
-                    CameraDisplacementBehaviour::None
+                    if speed.xsp >= 6.0 {
+                        CameraDisplacementBehaviour::ExtendRight
+                    } else if speed.xsp <= -6.0 {
+                        CameraDisplacementBehaviour::ExtendLeft
+                    } else {
+                        CameraDisplacementBehaviour::None
+                    }
                 };
 
                 camera.vertical_behaviour = vbehaviour;

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -89,14 +89,12 @@ impl LevelScreenSystem {
                         PlayerAction::Crouching => CameraDisplacementBehaviour::LookDown,
                         _ => CameraDisplacementBehaviour::None,
                     }
+                } else if speed.xsp >= 6.0 {
+                    CameraDisplacementBehaviour::ExtendRight
+                } else if speed.xsp <= -6.0 {
+                    CameraDisplacementBehaviour::ExtendLeft
                 } else {
-                    if speed.xsp >= 6.0 {
-                        CameraDisplacementBehaviour::ExtendRight
-                    } else if speed.xsp <= -6.0 {
-                        CameraDisplacementBehaviour::ExtendLeft
-                    } else {
-                        CameraDisplacementBehaviour::None
-                    }
+                    CameraDisplacementBehaviour::None
                 };
 
                 camera.vertical_behaviour = vbehaviour;

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -82,7 +82,61 @@ impl LevelScreenSystem {
         Ok(())
     }
 
+    fn draw_test_graphics(&self, context: &mut Context) -> GameResult {
+        // Draw a grid for camera testing
+        use crate::objects::player::physics::FAKE_GROUND_Y;
+        use ggez::graphics::{self, Color, MeshBuilder};
+        use glam::*;
+        let mut builder = MeshBuilder::new();
+
+        // Crosses on background
+        for i in 0..30 {
+            for j in 0..30 {
+                let center = glam::vec2(100.0 * i as f32, 100.0 * j as f32);
+                let _ = builder
+                    .line(
+                        &[
+                            glam::vec2(center.x, center.y - 10.0),
+                            glam::vec2(center.x, center.y + 10.0),
+                        ],
+                        1.0,
+                        Color::new(0.0, 1.0, 1.0, 0.3),
+                    )?
+                    .line(
+                        &[
+                            glam::vec2(center.x - 10.0, center.y),
+                            glam::vec2(center.x + 10.0, center.y),
+                        ],
+                        1.0,
+                        Color::new(0.0, 1.0, 1.0, 0.3),
+                    )?;
+            }
+        }
+
+        // Representation for floor
+        let _ = builder.line(
+            &[
+                glam::vec2(0.0, FAKE_GROUND_Y + 16.0 + 5.0),
+                glam::vec2(3000.0, FAKE_GROUND_Y + 16.0 + 5.0),
+            ],
+            5.0,
+            Color::new(0.3, 0.0, 0.2, 0.5),
+        )?;
+
+        let mesh = builder.build(context)?;
+        let position = if let Some(camera) = &self.camera {
+            camera.transform(Vec2::ZERO)
+        } else {
+            Vec2::ZERO
+        };
+        graphics::draw(context, &mesh, (position, 0.0, Color::WHITE))?;
+        Ok(())
+    }
+
     pub fn draw(&self, context: &mut Context) -> GameResult {
+        // Draw test graphics
+        self.draw_test_graphics(context)?;
+
         // Draw all animated sprites
         let mut query = <(&AnimatorData, &Animator, &Position)>::query();
         for (data, animator, position) in query.iter(&self.world) {

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -59,7 +59,7 @@ impl LevelScreenSystem {
             if (up && !down) || (!up && down) {
                 (self.camera_timer + 1).min(120)
             } else {
-                (self.camera_timer - 1).max(0)
+                0
             }
         };
 


### PR DESCRIPTION
Adiciona objeto de câmera a ser utilizado em uma tela, com os elementos:

- Capaz de seguir um objeto com posição;
- Capaz de realizar reposicionamento (mover-se para cima, baixo, ou esquerda/direita estendendo a visão do jogador ao correr);
- Limites da câmera com modificação de comportamento de acordo com estado no chão ou no ar;
- HUD básico de debug.

Closes #8.