### PR TITLE
Separa animações e Sprite Atlas

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -45,7 +45,7 @@ pub struct InputState {
 }
 
 /// A structure describing the input system.
-/// 
+///
 /// This structure is used to track the state of the
 /// input system in general, and to be updated by using
 /// the proper key down/up functions related to its input

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -1,7 +1,6 @@
 use super::sprite_atlas::SpriteAtlas;
 use crate::objects::general::Direction;
 use crate::objects::general::Position;
-use ggez::graphics::{self, DrawParam, Image, Rect};
 use ggez::{Context, GameError, GameResult};
 use glam::*;
 use std::collections::HashMap;

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -13,18 +13,22 @@ pub struct AnimationData {
     pub loopback_index: usize,
     pub speed: Duration,
 }
-
+/// A helper structure to build an animator.
+/// 
+/// Allows you to build an animator by adding animations to it.
 pub struct AnimatorBuilder {
     pub data: HashMap<String, AnimationData>,
 }
 
 impl AnimatorBuilder {
+    /// Creates a new animator builder.
     pub fn new() -> Self {
         Self {
             data: HashMap::new(),
         }
     }
 
+    /// Adds an animation to the builder.
     pub fn add_animation(
         &mut self,
         name: &str,
@@ -51,6 +55,7 @@ impl AnimatorBuilder {
         }
     }
 
+    /// Builds the animator.
     pub fn build(&self) -> Animator {
         Animator {
             data: self.data.clone(),
@@ -59,6 +64,8 @@ impl AnimatorBuilder {
     }
 }
 
+/// An animator structure, responsible for managing and
+/// storing information related to animations.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Animator {
     animation_name: String,
@@ -87,10 +94,12 @@ impl Default for Animator {
 }
 
 impl Animator {
+    /// Gets the current animation name.
     pub fn get_name(&self) -> String {
         self.animation_name.clone()
     }
 
+    /// Sets the current animation by its name, if it is registered.
     pub fn set(&mut self, animation: String) {
         // Set new animation, but leave current frame intact.
         if self.animation_name != animation {
@@ -103,14 +112,17 @@ impl Animator {
         }
     }
 
+    /// Sets the duration of a single animation frame.
     pub fn set_duration(&mut self, duration: Duration) {
         self.frame_duration = duration;
     }
 
+    /// Sets the duration of a single animation frame, in milliseconds.
     pub fn set_duration_ms(&mut self, duration: u64) {
         self.frame_duration = Duration::from_millis(duration);
     }
 
+    /// Updates the animation.
     pub fn update(&mut self) {
         if let Some(data) = self.data.get(&self.animation_name) {
             let now = Instant::now();
@@ -143,6 +155,10 @@ impl Animator {
         }
     }
 
+    /// Draws the current animation frame.
+    /// 
+    /// Requires the draw context and the sprite atlas, plus the center position
+    /// of the sprite.
     pub fn draw(
         &self,
         context: &mut Context,

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -1,3 +1,4 @@
+use super::sprite_atlas::SpriteAtlas;
 use crate::objects::general::Direction;
 use crate::objects::general::Position;
 use ggez::graphics::{self, DrawParam, Image, Rect};
@@ -5,22 +6,17 @@ use ggez::{Context, GameError, GameResult};
 use glam::*;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use super::sprite_atlas::SpriteAtlas;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AnimatorData {
-    pub atlas: SpriteAtlas,
     pub data: HashMap<String, (Vec<u32>, bool, usize, Duration)>,
 }
 
 impl AnimatorData {
-    pub fn new(context: &mut Context, path: &str, frame_size: Vec2) -> GameResult<Self> {
-        let atlas = SpriteAtlas::new(context, path, frame_size)?;
-
-        Ok(Self {
-            atlas,
+    pub fn new() -> Self {
+        Self {
             data: HashMap::new(),
-        })
+        }
     }
 
     pub fn add_animation(
@@ -144,31 +140,22 @@ impl Animator {
         }
     }
 
-    pub fn calculate_frame(&self, img_size: Vec2, frame_size: Vec2) -> Rect {
-        let frames_per_line = img_size.x / frame_size.x;
-        let frame_line = (self.current_frame as f32 / frames_per_line).trunc();
-        let frame_column = self.current_frame as f32 % frames_per_line;
-
-        let frame_size_texels = frame_size / img_size;
-
-        Rect::new(
-            frame_column * frame_size_texels.x,
-            frame_line * frame_size_texels.y,
-            frame_size_texels.x,
-            frame_size_texels.y,
-        )
-    }
-
     pub fn draw(
         &self,
         context: &mut Context,
+        atlas: &SpriteAtlas,
         animdata: &AnimatorData,
         hotspot: &Position,
     ) -> GameResult {
         if animdata.data.get(&self.animation_name).is_some() {
             let direction: f32 = self.direction.into();
             let xscale = direction * self.scale;
-            animdata.atlas.draw(context, self.current_frame, hotspot.0, glam::vec2(xscale, self.scale))?;
+            atlas.draw(
+                context,
+                self.current_frame,
+                hotspot.0,
+                glam::vec2(xscale, self.scale),
+            )?;
         }
         Ok(())
     }

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -14,7 +14,7 @@ pub struct AnimationData {
     pub speed: Duration,
 }
 /// A helper structure to build an animator.
-/// 
+///
 /// Allows you to build an animator by adding animations to it.
 pub struct AnimatorBuilder {
     pub data: HashMap<String, AnimationData>,
@@ -156,7 +156,7 @@ impl Animator {
     }
 
     /// Draws the current animation frame.
-    /// 
+    ///
     /// Requires the draw context and the sprite atlas, plus the center position
     /// of the sprite.
     pub fn draw(

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -2,3 +2,4 @@ pub mod animation;
 pub mod camera;
 pub mod general;
 pub mod player;
+pub mod sprite_atlas;

--- a/src/objects/player/animation.rs
+++ b/src/objects/player/animation.rs
@@ -1,41 +1,38 @@
 use super::{PlayerAction, PlayerSpeed, PlayerState};
-use crate::objects::animation::{Animator, AnimatorData};
+use crate::objects::animation::Animator;
 use ggez::GameResult;
 use legion::*;
 
 /// Performs updates on the animation component of the player.
 pub fn update(world: &mut World) -> GameResult {
-    let mut query = <(&PlayerState, &PlayerSpeed, &mut Animator, &AnimatorData)>::query();
-    for (state, speed, animator, animdata) in query.iter_mut(world) {
+    let mut query = <(&PlayerState, &PlayerSpeed, &mut Animator)>::query();
+    for (state, speed, animator) in query.iter_mut(world) {
         let gsp = speed.gsp.abs();
         if state.ground {
-            animator.set(
-                String::from(match state.action {
-                    PlayerAction::LookingUp => "lookup",
-                    PlayerAction::Crouching => "crouch",
-                    PlayerAction::Skidding => "skid",
-                    PlayerAction::Default => {
-                        if gsp >= 9.95 {
-                            "peel"
-                        } else if gsp >= 5.0 {
-                            "run"
-                        } else if gsp > 0.0 {
-                            "walk"
-                        } else {
-                            "idle"
-                        }
+            animator.set(String::from(match state.action {
+                PlayerAction::LookingUp => "lookup",
+                PlayerAction::Crouching => "crouch",
+                PlayerAction::Skidding => "skid",
+                PlayerAction::Default => {
+                    if gsp >= 9.95 {
+                        "peel"
+                    } else if gsp >= 5.0 {
+                        "run"
+                    } else if gsp > 0.0 {
+                        "walk"
+                    } else {
+                        "idle"
                     }
-                    _ => "walk", /* uhhhh wat */
-                }),
-                animdata,
-            );
+                }
+                _ => "walk", /* uhhhh wat */
+            }));
             // Animation duration
             if (gsp > 0.0) && (gsp < 9.95) {
                 animator.set_duration_ms((16.0 * (9.0 - gsp).max(1.0).floor()) as u64);
             }
         } else if (state.action == PlayerAction::Jumping) || (state.action == PlayerAction::Rolling)
         {
-            animator.set("roll".to_string(), animdata);
+            animator.set("roll".to_string());
             animator.set_duration_ms((16.0 * (4.0 - gsp).max(1.0).floor()) as u64);
         }
 

--- a/src/objects/player/general.rs
+++ b/src/objects/player/general.rs
@@ -25,6 +25,7 @@ impl Player {
     pub fn create(context: &mut Context, world: &mut World, knuckles: bool) -> GameResult<Entity> {
         use crate::objects::animation::*;
         use crate::objects::general::*;
+        use crate::objects::sprite_atlas::*;
 
         let constants = if knuckles {
             PlayerConstants::default_knuckles()
@@ -35,8 +36,8 @@ impl Player {
         let state = PlayerState::default();
         let position = Position::new(30.0, 240.0);
         let speed = PlayerSpeed::default();
-        let mut animation_data =
-            AnimatorData::new(context, "/sprites/sonic.png", Vec2::new(60.0, 60.0))?;
+        let atlas = SpriteAtlas::new(context, "/sprites/sonic.png", Vec2::new(60.0, 60.0))?;
+        let mut animation_data = AnimatorData::new();
         animation_data.with_data(&[
             (
                 "idle",
@@ -61,7 +62,7 @@ impl Player {
         let mut animator = Animator::default();
         animator.set("idle".to_string(), &animation_data);
 
-        Ok(world.push((state, constants, position, speed, animation_data, animator)))
+        Ok(world.push((state, constants, position, speed, atlas, animation_data, animator)))
     }
 
     /// Respawns all players in the world.

--- a/src/objects/player/general.rs
+++ b/src/objects/player/general.rs
@@ -1,8 +1,6 @@
-use super::PlayerAction;
 use super::PlayerConstants;
 use super::PlayerSpeed;
 use super::PlayerState;
-use crate::input::Input;
 use crate::objects::general::Position;
 use ggez::Context;
 use ggez::GameResult;
@@ -33,11 +31,6 @@ impl Player {
             PlayerConstants::default()
         };
 
-        let built = AnimatorBuilder::new()
-            .add_animation("run", &[11, 12, 13, 14], true, 0, 63)?
-            .add_animation("skid", &[23], true, 0, 1000)?
-            .build();
-
         let state = PlayerState::default();
         let position = Position::new(30.0, 240.0);
         let speed = PlayerSpeed::default();
@@ -67,14 +60,7 @@ impl Player {
 
         animator.set("idle".to_string());
 
-        Ok(world.push((
-            state,
-            constants,
-            position,
-            speed,
-            atlas,
-            animator,
-        )))
+        Ok(world.push((state, constants, position, speed, atlas, animator)))
     }
 
     /// Respawns all players in the world.

--- a/src/objects/player/general.rs
+++ b/src/objects/player/general.rs
@@ -33,13 +33,18 @@ impl Player {
             PlayerConstants::default()
         };
 
+        let built = AnimatorBuilder::new()
+            .add_animation("run", &[11, 12, 13, 14], true, 0, 63)?
+            .add_animation("skid", &[23], true, 0, 1000)?
+            .build();
+
         let state = PlayerState::default();
         let position = Position::new(30.0, 240.0);
         let speed = PlayerSpeed::default();
         let atlas = SpriteAtlas::new(context, "/sprites/sonic.png", Vec2::new(60.0, 60.0))?;
-        let mut animation_data = AnimatorData::new();
-        animation_data.with_data(&[
-            (
+
+        let mut animator = AnimatorBuilder::new()
+            .add_animation(
                 "idle",
                 &[
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2,
@@ -48,21 +53,28 @@ impl Player {
                 true,
                 26,
                 125,
-            ),
-            ("walk", &[5, 6, 7, 8, 9, 10], true, 0, 100),
-            ("run", &[11, 12, 13, 14], true, 0, 63),
-            ("roll", &[15, 16, 17, 16, 19, 16, 21, 16], true, 0, 125),
-            ("skid", &[23], true, 0, 1000),
-            ("peel", &[24, 25, 26, 27], true, 0, 60),
-            ("push", &[28, 29, 30, 31], true, 0, 500),
-            ("crouch", &[32], true, 0, 1000),
-            ("lookup", &[33], true, 0, 1000),
-            ("dead", &[34], true, 0, 1000),
-        ])?;
-        let mut animator = Animator::default();
-        animator.set("idle".to_string(), &animation_data);
+            )?
+            .add_animation("walk", &[5, 6, 7, 8, 9, 10], true, 0, 100)?
+            .add_animation("run", &[11, 12, 13, 14], true, 0, 63)?
+            .add_animation("roll", &[15, 16, 17, 16, 19, 16, 21, 16], true, 0, 125)?
+            .add_animation("skid", &[23], true, 0, 1000)?
+            .add_animation("peel", &[24, 25, 26, 27], true, 0, 60)?
+            .add_animation("push", &[28, 29, 30, 31], true, 0, 500)?
+            .add_animation("crouch", &[32], true, 0, 1000)?
+            .add_animation("lookup", &[33], true, 0, 1000)?
+            .add_animation("dead", &[34], true, 0, 1000)?
+            .build();
 
-        Ok(world.push((state, constants, position, speed, atlas, animation_data, animator)))
+        animator.set("idle".to_string());
+
+        Ok(world.push((
+            state,
+            constants,
+            position,
+            speed,
+            atlas,
+            animator,
+        )))
     }
 
     /// Respawns all players in the world.

--- a/src/objects/player/physics.rs
+++ b/src/objects/player/physics.rs
@@ -1,6 +1,5 @@
 use super::{PlayerAction, PlayerConstants, PlayerSpeed, PlayerState};
 use crate::input::Input;
-use crate::objects::general::Position;
 use ggez::GameResult;
 use legion::*;
 
@@ -9,7 +8,7 @@ use legion::*;
 pub const FAKE_GROUND_Y: f32 = 800.0;
 
 /// Updates the player's logic based on the input.
-/// 
+///
 /// This is the entry point for updating anything related
 /// to physics, including movement and collision.
 pub fn update(world: &mut World, input: &Input) -> GameResult {

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -10,10 +10,8 @@ use glam::*;
 /// and always equally spaced.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpriteAtlas {
-    /// The image that contains the frames.
-    pub texture: Image,
-    /// The size of each frame.
-    pub frame_size: Vec2,
+    texture: Image,
+    frame_size: Vec2,
     half_frame: Vec2,
 }
 

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -2,6 +2,7 @@ use ggez::graphics::{self, DrawParam, Image, Rect};
 use ggez::{Context, GameResult};
 use glam::*;
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct SpriteAtlas {
     pub texture: Image,
     pub frame_size: Vec2,
@@ -25,9 +26,9 @@ impl SpriteAtlas {
     fn calculate_frame(&self, frame: u32) -> Rect {
         let image_size = self.get_image_size();
         let frames_per_line = image_size.x / self.frame_size.x;
-        let frame_line = (frame as f32 / frames_per_line as f32).trunc();
+        let frame_line = (frame as f32 / frames_per_line).trunc();
         let frame_column = frame as f32 % frames_per_line;
-        let frame_size_texels = self.frame_size * image_size;
+        let frame_size_texels = self.frame_size / image_size;
 
         Rect::new(
             frame_column * frame_size_texels.x,

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -2,14 +2,26 @@ use ggez::graphics::{self, DrawParam, Image, Rect};
 use ggez::{Context, GameResult};
 use glam::*;
 
+/// A sprite atlas is a collection of frames that can be used to draw
+/// a single sprite.
+/// 
+/// Frames on the sprite atlas are assumed to be arranged in a grid,
+/// numerated from 0 in the left-right, top-bottom order, respectively,
+/// and always equally spaced.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpriteAtlas {
+    /// The image that contains the frames.
     pub texture: Image,
+    /// The size of each frame.
     pub frame_size: Vec2,
     half_frame: Vec2,
 }
 
 impl SpriteAtlas {
+    /// Creates a new sprite atlas from an image.
+    /// 
+    /// The path to the image is relative to the `resources` directory,
+    /// and the frame size is required in pixels.
     pub fn new(context: &mut Context, path: &str, frame_size: Vec2) -> GameResult<Self> {
         let texture = Image::new(context, path)?;
         Ok(Self {
@@ -19,6 +31,7 @@ impl SpriteAtlas {
         })
     }
 
+    /// Gets the size of the entire sprite atlas.
     pub fn get_image_size(&self) -> Vec2 {
         glam::vec2(self.texture.width() as f32, self.texture.height() as f32)
     }
@@ -38,6 +51,10 @@ impl SpriteAtlas {
         )
     }
 
+    /// Draws a frame of the sprite atlas.
+    /// 
+    /// Requires a drawing context, the number of the frame, the center position
+    /// of the sprite on screen, and a scale factor related to each axis.
     pub fn draw(
         &self,
         context: &mut Context,

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -1,0 +1,56 @@
+use ggez::graphics::{self, DrawParam, Image, Rect};
+use ggez::{Context, GameResult};
+use glam::*;
+
+pub struct SpriteAtlas {
+    pub texture: Image,
+    pub frame_size: Vec2,
+    half_frame: Vec2,
+}
+
+impl SpriteAtlas {
+    pub fn new(context: &mut Context, path: &str, frame_size: Vec2) -> GameResult<Self> {
+        let texture = Image::new(context, path)?;
+        Ok(Self {
+            texture,
+            frame_size,
+            half_frame: frame_size / 2.0,
+        })
+    }
+
+    pub fn get_image_size(&self) -> Vec2 {
+        glam::vec2(self.texture.width() as f32, self.texture.height() as f32)
+    }
+
+    fn calculate_frame(&self, frame: u32) -> Rect {
+        let image_size = self.get_image_size();
+        let frames_per_line = image_size.x / self.frame_size.x;
+        let frame_line = (frame as f32 / frames_per_line as f32).trunc();
+        let frame_column = frame as f32 % frames_per_line;
+        let frame_size_texels = self.frame_size * image_size;
+
+        Rect::new(
+            frame_column * frame_size_texels.x,
+            frame_line * frame_size_texels.y,
+            frame_size_texels.x,
+            frame_size_texels.y,
+        )
+    }
+
+    pub fn draw(
+        &self,
+        context: &mut Context,
+        frame: u32,
+        hotspot: Vec2,
+        scale: Vec2,
+    ) -> GameResult {
+        let frame = self.calculate_frame(frame);
+        let half_frame = self.half_frame * scale;
+        let destination = hotspot - half_frame;
+        let params = DrawParam::default()
+            .src(frame)
+            .scale(scale)
+            .dest(destination);
+        graphics::draw(context, &self.texture, params)
+    }
+}

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -4,7 +4,7 @@ use glam::*;
 
 /// A sprite atlas is a collection of frames that can be used to draw
 /// a single sprite.
-/// 
+///
 /// Frames on the sprite atlas are assumed to be arranged in a grid,
 /// numerated from 0 in the left-right, top-bottom order, respectively,
 /// and always equally spaced.
@@ -19,7 +19,7 @@ pub struct SpriteAtlas {
 
 impl SpriteAtlas {
     /// Creates a new sprite atlas from an image.
-    /// 
+    ///
     /// The path to the image is relative to the `resources` directory,
     /// and the frame size is required in pixels.
     pub fn new(context: &mut Context, path: &str, frame_size: Vec2) -> GameResult<Self> {
@@ -52,7 +52,7 @@ impl SpriteAtlas {
     }
 
     /// Draws a frame of the sprite atlas.
-    /// 
+    ///
     /// Requires a drawing context, the number of the frame, the center position
     /// of the sprite on screen, and a scale factor related to each axis.
     pub fn draw(

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -3,10 +3,10 @@ use crate::objects::animation::*;
 use crate::objects::camera::Camera;
 use crate::objects::general::*;
 use crate::objects::player::{self, *};
+use crate::objects::sprite_atlas::SpriteAtlas;
 use crate::screen_systems::Navigation;
 use ggez::{Context, GameResult};
 use legion::*;
-use crate::objects::sprite_atlas::SpriteAtlas;
 
 /// Defines the state for a level screen system.
 pub struct LevelScreenSystem {

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -50,9 +50,9 @@ impl LevelScreenSystem {
         player::physics::update(&mut self.world, input)?;
 
         // Update all animated sprites
-        let mut query = <(&AnimatorData, &mut Animator)>::query();
-        for (data, animator) in query.iter_mut(&mut self.world) {
-            animator.update(data);
+        let mut query = <&mut Animator>::query();
+        for animator in query.iter_mut(&mut self.world) {
+            animator.update();
         }
 
         // Update camera panning
@@ -214,14 +214,14 @@ impl LevelScreenSystem {
         self.draw_test_graphics(context)?;
 
         // Draw all animated sprites
-        let mut query = <(&SpriteAtlas, &AnimatorData, &Animator, &Position)>::query();
-        for (atlas, data, animator, position) in query.iter(&self.world) {
+        let mut query = <(&SpriteAtlas, &Animator, &Position)>::query();
+        for (atlas, animator, position) in query.iter(&self.world) {
             let hotspot = Position::wrap(if let Some(camera) = &self.camera {
                 camera.transform(position.0)
             } else {
                 position.0
             });
-            animator.draw(context, atlas, data, &hotspot)?;
+            animator.draw(context, atlas, &hotspot)?;
         }
 
         // Draw sensors and camera

--- a/src/screen_systems/levelscreen/system.rs
+++ b/src/screen_systems/levelscreen/system.rs
@@ -6,6 +6,7 @@ use crate::objects::player::{self, *};
 use crate::screen_systems::Navigation;
 use ggez::{Context, GameResult};
 use legion::*;
+use crate::objects::sprite_atlas::SpriteAtlas;
 
 /// Defines the state for a level screen system.
 pub struct LevelScreenSystem {
@@ -213,14 +214,14 @@ impl LevelScreenSystem {
         self.draw_test_graphics(context)?;
 
         // Draw all animated sprites
-        let mut query = <(&AnimatorData, &Animator, &Position)>::query();
-        for (data, animator, position) in query.iter(&self.world) {
+        let mut query = <(&SpriteAtlas, &AnimatorData, &Animator, &Position)>::query();
+        for (atlas, data, animator, position) in query.iter(&self.world) {
             let hotspot = Position::wrap(if let Some(camera) = &self.camera {
                 camera.transform(position.0)
             } else {
                 position.0
             });
-            animator.draw(context, data, &hotspot)?;
+            animator.draw(context, atlas, data, &hotspot)?;
         }
 
         // Draw sensors and camera

--- a/src/screen_systems/mod.rs
+++ b/src/screen_systems/mod.rs
@@ -12,7 +12,7 @@ pub use titlescreen::system::TitleScreenSystem;
 
 /// Represents a collection of screen systems, which can
 /// be switched between.
-/// 
+///
 /// The screen system is responsible for updating and drawing
 /// the current screen.
 pub struct ScreenSystems {


### PR DESCRIPTION
- Cria estrutura de Sprite Atlas;
- Separa a renderização de quadros da animação de forma a utilizar um componente de Sprite Atlas como apoio;
- Move os dados da estrutura `AnimatorData` para dentro de `Animator`;
- Remove `AnimatorData`;
- Cria estrutura `AnimationData` para representar os dados de uma animação qualquer, sendo então utilizada no HashMap de animações;
- Cria estrutura `AnimatorBuilder`, uma estrutura de builder pattern para criar um `Animator` já populado com dados de animações.

Closes #9.