### PR TITLE
Utiliza SpriteBatch na renderização de SpriteAtlas e animações

### DIFF
--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -163,7 +163,8 @@ impl Animator {
             atlas.queue_draw(
                 self.current_frame,
                 hotspot.0,
-                glam::vec2(xscale, self.scale))
+                glam::vec2(xscale, self.scale),
+            )
         } else {
             Ok(())
         }

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -168,7 +168,7 @@ impl Animator {
         if self.data.get(&self.animation_name).is_some() {
             let direction: f32 = self.direction.into();
             let xscale = direction * self.scale;
-            atlas.draw(
+            atlas.immediate_draw(
                 context,
                 self.current_frame,
                 hotspot.0,

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -66,6 +66,10 @@ impl AnimatorBuilder {
 
 /// An animator structure, responsible for managing and
 /// storing information related to animations.
+/// Animators are responsible for handling logic, and
+/// queueing SpriteAtlas for drawing frames in specific
+/// locations. To perform actual rendering, draw the
+/// sprite atlas in non-immediate mode.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Animator {
     animation_name: String,
@@ -123,7 +127,7 @@ impl Animator {
     }
 
     /// Updates the animation.
-    pub fn update(&mut self) {
+    pub fn update(&mut self, atlas: &mut SpriteAtlas, hotspot: &Position) -> GameResult {
         if let Some(data) = self.data.get(&self.animation_name) {
             let now = Instant::now();
             let delta = (now - self.last_update) as Duration;
@@ -152,29 +156,16 @@ impl Animator {
             }
             // Fetch animation frame number
             self.current_frame = *data.frames.get(self.frame_count).unwrap_or(&0);
-        }
-    }
 
-    /// Draws the current animation frame.
-    ///
-    /// Requires the draw context and the sprite atlas, plus the center position
-    /// of the sprite.
-    pub fn draw(
-        &self,
-        context: &mut Context,
-        atlas: &SpriteAtlas,
-        hotspot: &Position,
-    ) -> GameResult {
-        if self.data.get(&self.animation_name).is_some() {
+            // Queue drawing
             let direction: f32 = self.direction.into();
             let xscale = direction * self.scale;
-            atlas.immediate_draw(
-                context,
+            atlas.queue_draw(
                 self.current_frame,
                 hotspot.0,
-                glam::vec2(xscale, self.scale),
-            )?;
+                glam::vec2(xscale, self.scale))
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 }

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -1,4 +1,5 @@
 use ggez::graphics::{self, DrawParam, Image, Rect};
+use ggez::graphics::spritebatch::SpriteBatch;
 use ggez::{Context, GameResult};
 use glam::*;
 
@@ -11,6 +12,7 @@ use glam::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpriteAtlas {
     texture: Image,
+    batch: SpriteBatch,
     frame_size: Vec2,
     half_frame: Vec2,
 }
@@ -22,8 +24,10 @@ impl SpriteAtlas {
     /// and the frame size is required in pixels.
     pub fn new(context: &mut Context, path: &str, frame_size: Vec2) -> GameResult<Self> {
         let texture = Image::new(context, path)?;
+        let batch = SpriteBatch::new(texture.clone());
         Ok(Self {
             texture,
+            batch,
             frame_size,
             half_frame: frame_size / 2.0,
         })
@@ -49,11 +53,24 @@ impl SpriteAtlas {
         )
     }
 
-    /// Draws a frame of the sprite atlas.
+    pub fn queue_draw(&mut self, frame: u32, hotspot: Vec2, scale: Vec2) -> GameResult {
+        let frame = self.calculate_frame(frame);
+        let half_frame = self.half_frame * scale;
+        let destination = hotspot - half_frame;
+        let params = DrawParam::default()
+            .src(frame)
+            .scale(scale)
+            .dest(destination);
+        self.batch.add(params);
+        Ok(())
+    }
+
+
+    /// Draws a frame of the sprite atlas, immediately.
     ///
     /// Requires a drawing context, the number of the frame, the center position
     /// of the sprite on screen, and a scale factor related to each axis.
-    pub fn draw(
+    pub fn immediate_draw(
         &self,
         context: &mut Context,
         frame: u32,
@@ -68,5 +85,14 @@ impl SpriteAtlas {
             .scale(scale)
             .dest(destination);
         graphics::draw(context, &self.texture, params)
+    }
+
+    pub fn draw(
+        &mut self,
+        context: &mut Context,
+    ) -> GameResult {
+        graphics::draw(context, &self.batch, DrawParam::default())?;
+        self.batch.clear();
+        Ok(())
     }
 }

--- a/src/objects/sprite_atlas.rs
+++ b/src/objects/sprite_atlas.rs
@@ -1,5 +1,5 @@
-use ggez::graphics::{self, DrawParam, Image, Rect};
 use ggez::graphics::spritebatch::SpriteBatch;
+use ggez::graphics::{self, DrawParam, Image, Rect};
 use ggez::{Context, GameResult};
 use glam::*;
 
@@ -65,7 +65,6 @@ impl SpriteAtlas {
         Ok(())
     }
 
-
     /// Draws a frame of the sprite atlas, immediately.
     ///
     /// Requires a drawing context, the number of the frame, the center position
@@ -87,12 +86,15 @@ impl SpriteAtlas {
         graphics::draw(context, &self.texture, params)
     }
 
-    pub fn draw(
-        &mut self,
-        context: &mut Context,
-    ) -> GameResult {
-        graphics::draw(context, &self.batch, DrawParam::default())?;
+    /// Clears the frame queue. Should be called once
+    /// at the beginning of each frame.
+    pub fn clear(&mut self) {
         self.batch.clear();
-        Ok(())
+    }
+
+    /// Draw queued frames from the SpriteAtlas, with optimal
+    /// performace.
+    pub fn draw(&self, context: &mut Context) -> GameResult {
+        graphics::draw(context, &self.batch, DrawParam::default())
     }
 }


### PR DESCRIPTION
- Utiliza estruturas de `SpriteBatch` na renderização do `SpriteAtlas`;
- Remove funções de renderização do `Animator` em favor de uso direto da renderização do `SpriteAtlas`;
- Adiciona renderização de frame único com baixa performance no `SpriteBatch`, para casos específicos.

Closes #15.